### PR TITLE
Use older version of ini package due to safe encode values with '=' changed in 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "error-plus": "0.0.1",
     "execSync": "^1.0.1-pre",
     "fleetctl-ssh": "0.1.4",
-    "ini": "^1.1.0",
+    "ini": "1.3.2",
     "joi": "^4.0.0",
     "json-override": "^0.1.2",
     "leveldown": "^0.10.2",


### PR DESCRIPTION
ref #3 

https://github.com/isaacs/ini/commit/9c3b405331f7e0a0c624fe6ae6be4af3b1460978
