### PR TITLE
Encode values issue

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,7 +40,7 @@
     "new-cap": 2,
     "no-spaced-func": 2,
     "no-space-before-semi": 2,
-    "space-unary-word-ops": 2,
+    "space-unary-ops": 2,
     "quotes": [2, "single"]
   }
 }

--- a/fig.yml
+++ b/fig.yml
@@ -14,7 +14,7 @@ scheduler:
   ports:
    - "9002:9002"
 svcdir:
-  image: lukebond/paz-service-directory
+  image: quay.io/yldio/paz-service-directory
   environment:
    - PAZ_SERVICE_DIRECTORY_PORT=9001
    - DEBUG

--- a/hooks/deploy/model.js
+++ b/hooks/deploy/model.js
@@ -48,8 +48,8 @@ module.exports = function Service(cfg) {
       function (err, svcReq, svcRes, serviceObject) {
         if (err && err.message.match(/Key\ not\ found/g)) {
           return cb(new _Error(
-            'Service ' + serviceName + ' is not in the service directory.', { 
-            statusCode: 404 
+            'Service ' + serviceName + ' is not in the service directory.', {
+            statusCode: 404
           }));
         } else if (err) {
           return cb(err);
@@ -57,13 +57,13 @@ module.exports = function Service(cfg) {
         req.log.debug(serviceObject, 'Service object from service directory');
 
         deploy(serviceName, serviceObject.doc, hookObject, sshHost, options, db,
-          function (err, versionNumber) {
-            if (err) {
-              req.log.error(err);
-              return cb(err);
+          function (deployerr, versionNumber) {
+            if (deployerr) {
+              req.log.error(deployerr);
+              return cb(deployerr);
             }
             req.log.info({
-              message: 
+              message:
                 'Successfully deployed ' + serviceName + ' v' + versionNumber
             });
             return cb(null, { statusCode: 200 });

--- a/hooks/dockerhub/model.js
+++ b/hooks/dockerhub/model.js
@@ -53,10 +53,10 @@ module.exports = function Service(cfg) {
         var serviceName = serviceObject.name;
 
         deploy(serviceName, serviceObject, hookObject, sshHost, options, db,
-          function (err, versionNumber) {
-            if (err) {
-              req.log.error(err);
-              return cb(err);
+          function (deployerr, versionNumber) {
+            if (deployerr) {
+              req.log.error(deployerr);
+              return cb(deployerr);
             }
             req.log.info({
               message: 'Successfully deployed ' + serviceName + ' v' + versionNumber

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -37,11 +37,10 @@ function deploy(serviceName, serviceObject, hookObject, sshHost, options, db, cb
 
   // determine next version number for this service
   var versionDBKey = 'latest!' + serviceName;
-  db.get(versionDBKey , function(err, prevVersion) {
+  db.get(versionDBKey, function(err, prevVersion) {
     if (err && err.notFound) {
       prevVersion = 0;
-    }
-    else if (err) {
+    } else if (err) {
       return cb(err);
     }
     var versionNumber = +prevVersion + 1;
@@ -55,8 +54,7 @@ function deploy(serviceName, serviceObject, hookObject, sshHost, options, db, cb
     var fleetctl = new FleetCtl(sshHost, options);
     if (options.deploy) {
       tasks = getFleetCtlTasks(fleetctl, serviceObject, unitfilesArray);
-    }
-    else {
+    } else {
       tasks = getMockTasks(serviceObject, unitfilesArray);
     }
     debug('# tasks: ' + tasks.length);
@@ -89,10 +87,10 @@ function deploy(serviceName, serviceObject, hookObject, sshHost, options, db, cb
 
       debug('Going to insert into DB: ' + JSON.stringify(puts));
 
-      db.batch(puts, function(err) {
-        if (err) {
-          debug('DB error: ' + err);
-          return cb(err);
+      db.batch(puts, function(dberr) {
+        if (dberr) {
+          debug('DB error: ' + dberr);
+          return cb(dberr);
         }
         debug('DB insert okay');
         return cb(null, versionNumber);

--- a/lib/unitfile.js
+++ b/lib/unitfile.js
@@ -25,7 +25,7 @@ function getServiceUnitFiles(service, unitNameBase, instance) {
     iniObj.Service.User = service.config.user;
   }
   iniObj.Service.ExecStartPre = '/bin/bash -c "docker pull ' + service.dockerRepository + ' && docker inspect ' + unitName + ' >/dev/null 2>&1 && docker rm -f ' + unitName + ' || true"';
-  iniObj.Service.ExecStart = '/usr/bin/docker run --name=' + unitName;
+  iniObj.Service.ExecStart = '/usr/bin/docker run --name ' + unitName;
   if (!service.config.ports || !service.config.ports.length) {
     iniObj.Service.ExecStart += ' -P';
   } else {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "expectations": "^0.2.5",
     "lab": "^4.4.4",
     "precommit-hook": "^1.0.7",
-    "supertest": "^0.12.0"
+    "supertest": "^0.12.0",
+    "eslint": "0.18.0",
+    "jscs": "1.12.0"
   },
   "precommit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "error-plus": "0.0.1",
     "execSync": "^1.0.1-pre",
     "fleetctl-ssh": "0.1.4",
-    "ini": "^1.1.0",
+    "ini": "1.3.2",
     "joi": "^4.0.0",
     "json-override": "^0.1.2",
     "leveldown": "^0.10.2",

--- a/resources/config/model.js
+++ b/resources/config/model.js
@@ -29,16 +29,16 @@ module.exports = function Service(cfg) {
       if (doc) {
         dbKey = 'deploy!' + name + '!' + doc;
 
-        db.get(dbKey, function(err, doc) {
-          if (err && err.notFound) {
-            return cb(new _Error(err, {statusCode: 404, message: err.message}));
-          } else if (err) {
-            return cb(new _Error(err, {statusCode: 500, message: err.message}));
+        db.get(dbKey, function(err2, doc2) {
+          if (err2 && err.notFound) {
+            return cb(new _Error(err2, {statusCode: 404, message: err2.message}));
+          } else if (err2) {
+            return cb(new _Error(err2, {statusCode: 500, message: err2.message}));
           }
 
-          if (doc) {
+          if (doc2) {
             return cb(null, {
-              doc: doc.service.config
+              doc2: doc2.service.config
             });
           }
         });

--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ var opts = {
     +(argv.port || process.env[APP_NAME + '_PORT'] || '9002'),
   'loglevel':
     argv.loglevel || process.env[APP_NAME + '_LOGLEVEL'] || 'info',
-  'dbname': argv.dbname || process.env[APP_NAME + '_DBNAME']  || 'db',
+  'dbname': argv.dbname || process.env[APP_NAME + '_DBNAME'] || 'db',
   'svcdir':
     argv.svcdir || process.env[APP_NAME + '_SVCDIR_URL'] ||
     'localhost:9001',
@@ -156,12 +156,12 @@ Server.prototype.close = function(cb) {
     if (err) {
       console.log(err);
     }
-    this.db.close(function(err) {
-      if (err) {
-        console.log(err);
+    this.db.close(function(err2) {
+      if (err2) {
+        console.log(err2);
       }
       return cb();
-    }.bind(this));
+    });
   }.bind(this));
 };
 

--- a/test/hooks/deploy.js
+++ b/test/hooks/deploy.js
@@ -13,7 +13,7 @@ var schedulerPort = process.env.SCHEDULER_PORT || 9002;
 var svcDirPort = process.env.SVCDIR_PORT || 9001;
 
 var schedulerPath = ['http://', host, ':', schedulerPort].join('');
-var svcDirPath    = ['http://', host, ':', svcDirPort].join('');
+var svcDirPath = ['http://', host, ':', svcDirPort].join('');
 
 lab.experiment('hooks/deploy', function() {
   var scheduler = supertest(schedulerPath);

--- a/test/hooks/dockerhub.js
+++ b/test/hooks/dockerhub.js
@@ -14,7 +14,7 @@ var schedulerPort = process.env.SCHEDULER_PORT || 9002;
 var svcDirPort = process.env.SVCDIR_PORT || 9001;
 
 var schedulerPath = ['http://', host, ':', schedulerPort].join('');
-var svcDirPath    = ['http://', host, ':', svcDirPort].join('');
+var svcDirPath = ['http://', host, ':', svcDirPort].join('');
 
 lab.experiment('hooks/dockerhub', function() {
   var scheduler = supertest(schedulerPath);

--- a/test/lib/unitfile.js
+++ b/test/lib/unitfile.js
@@ -69,7 +69,7 @@ lab.experiment('unitfile', function() {
 
     inis.forEach(function(ini) {
       var execStartLine = ini.unitfile.match(/ExecStart=([^\n]+)\n/);
-      expect(execStartLine.split(' ')[0].substring(0, 1)).to.be.equal('/');
+      expect(execStartLine[1][0]).to.be.equal('/');
     });
 
     done();

--- a/test/resources/config.js
+++ b/test/resources/config.js
@@ -14,7 +14,7 @@ var schedulerPort = process.env.SCHEDULER_PORT || 9002;
 var svcDirPort = process.env.SVCDIR_PORT || 9001;
 
 var schedulerPath = ['http://', host, ':', schedulerPort].join('');
-var svcDirPath    = ['http://', host, ':', svcDirPort].join('');
+var svcDirPath = ['http://', host, ':', svcDirPort].join('');
 
 lab.experiment('config', function() {
   var scheduler = supertest(schedulerPath);


### PR DESCRIPTION
ref #5

Please take a look, now should passed the test 
'Check that the created unit file\'s ExecStart line begins with an absolute path'.

The docker image lukebond/paz-service-directory is no longer exist on the docker hub, I had to update the fig.yml file. Same issue in the sub project paz-orchestrator.

However, I can't starting the scheduler server for some reason,
(hit the issue https://github.com/mgutz/execSync/issues/27)
and notice that execSync is no longer maintained.

``` bash
root@dev2:~/paz-scheduler# fig up
Recreating pazscheduler_svcdir_1...
Recreating pazscheduler_etcd_1...
Recreating pazscheduler_scheduler_1...
Attaching to pazscheduler_svcdir_1, pazscheduler_etcd_1, pazscheduler_scheduler_1
etcd_1      | [etcd] Mar 30 17:59:09.570 WARNING   | Using the directory c599a11acf55.etcd as the etcd curation directory because a directory was not specified.
etcd_1      | [etcd] Mar 30 17:59:09.572 INFO      | c599a11acf55 is starting a new cluster
etcd_1      | [etcd] Mar 30 17:59:09.593 INFO      | etcd server [name c599a11acf55, listen on :4001, advertised url http://127.0.0.1:4001]
etcd_1      | [etcd] Mar 30 17:59:09.639 INFO      | peer server [name c599a11acf55, listen on :7001, advertised url http://127.0.0.1:7001]
etcd_1      | [etcd] Mar 30 17:59:09.640 INFO      | c599a11acf55 starting in peer mode
etcd_1      | [etcd] Mar 30 17:59:09.642 INFO      | c599a11acf55: state changed from 'initialized' to 'follower'.
etcd_1      | [etcd] Mar 30 17:59:09.642 INFO      | c599a11acf55: state changed from 'follower' to 'leader'.
etcd_1      | [etcd] Mar 30 17:59:09.645 INFO      | c599a11acf55: leader changed from '' to 'c599a11acf55'.
svcdir_1    | Starting server
svcdir_1    | {"name":"paz-service-directory_log","hostname":"d144b79c6ce8","pid":6,"level":30,"msg":"paz-service-directory is now running on port 9001","time":"2015-03-30T17:59:09.998Z","v":0}
scheduler_1 | module.js:338
scheduler_1 |     throw err;
scheduler_1 |           ^
scheduler_1 | Error: Cannot find module './build/Release/shell'
scheduler_1 |     at Function.Module._resolveFilename (module.js:336:15)
scheduler_1 |     at Function.Module._load (module.js:278:25)
scheduler_1 |     at Module.require (module.js:365:17)
scheduler_1 |     at require (module.js:384:17)
scheduler_1 |     at Object.<anonymous> (/usr/src/app/node_modules/execSync/index.js:30:11)
scheduler_1 |     at Module._compile (module.js:460:26)
scheduler_1 |     at Object.Module._extensions..js (module.js:478:10)
scheduler_1 |     at Module.load (module.js:355:32)
scheduler_1 |     at Function.Module._load (module.js:310:12)
scheduler_1 |     at Module.require (module.js:365:17)
pazscheduler_scheduler_1 exited with code 1
Gracefully stopping... (press Ctrl+C again to force)
Stopping pazscheduler_etcd_1...
Stopping pazscheduler_svcdir_1...
```

``` bash
root@dev2:~/paz-scheduler# npm test

> paz-scheduler@0.0.1 test /root/paz-scheduler
> fig up -d && lab && fig stop

Recreating pazscheduler_svcdir_1...
Recreating pazscheduler_etcd_1...
Recreating pazscheduler_scheduler_1...


  xxxx......xxx

Test script errors:

Could not deploy service: Error: connect ECONNREFUSED


There were 1 test script error(s).

Failed tests:

  1) hooks/deploy POST /hooks/deploy should return a 200 status code depending on body of request:

      Error: connect ECONNREFUSED

      at errnoException (net.js:905:11)
      at Object.afterConnect [as oncomplete] (net.js:896:19)

  2) hooks/deploy POST /hooks/deploy should return a 400 status code if there is no service name:

      Error: connect ECONNREFUSED

      at errnoException (net.js:905:11)
      at Object.afterConnect [as oncomplete] (net.js:896:19)

  3) hooks/dockerhub POST /hooks/dockerhub should return a 200 status code when a correct request body is sent:

      Error: connect ECONNREFUSED

      at errnoException (net.js:905:11)
      at Object.afterConnect [as oncomplete] (net.js:896:19)

  4) hooks/dockerhub POST /hooks/dockerhub should return a 400 status code when an incorrect request body is sent:

      Error: connect ECONNREFUSED

      at errnoException (net.js:905:11)
      at Object.afterConnect [as oncomplete] (net.js:896:19)

  11) config GET /config/:name/version/latest returns 200 with a config:





  12) config GET /config/:name/version/:version should return 200 with a config doc:





  13) config GET /config/:name/version/:version should return 404 when version doesn't exist:






7 of 13 tests failed
Test duration: 9161 ms
No global variable leaks detected

npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0

```

Since it's an open source project I think it would be great to have a public CI like travis.io integrated so that it will shows the test result for each PR =)
